### PR TITLE
SearchGames now returns a list instead of a single item

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run it directly via `dotnet run`:
 dotnet run
 ```
 
-### Environment Variables [currently Windows only]
+### Environment Variables
 
 #### IGDB
 

--- a/gamebox/Connectors/IGDB/IGDBGameSource.cs
+++ b/gamebox/Connectors/IGDB/IGDBGameSource.cs
@@ -35,7 +35,7 @@ namespace GameBox.Connectors.IGDB
                     { "Authorization", $"Bearer {token.access_token}" }
                 }
             );
-            if (games == null || games.Count == 0)
+            if (games?.Count == 0)
                 return null;
 
             string gameIDs = string.Join(",", games?.Select(game => game.id) ?? new List<int>());
@@ -48,6 +48,8 @@ namespace GameBox.Connectors.IGDB
                     { "Authorization", $"Bearer {token.access_token}" }
                 }
             );
+            if (covers?.Count == 0)
+                return null;
 
             string totalIDs = string.Join(",", games.Select(game => string.Join(",", game.platforms.Select(platform => platform.ToString()))));
             int count = totalIDs.Split(",").Length;
@@ -61,7 +63,7 @@ namespace GameBox.Connectors.IGDB
                     { "Authorization", $"Bearer {token.access_token}" }
                 }
             );
-            if (platforms == null)
+            if (platforms?.Count == 0)
                 return null;
 
             List<ExternalGame> externalGames = new List<ExternalGame>();
@@ -70,10 +72,10 @@ namespace GameBox.Connectors.IGDB
                 int extID = game.id;
                 string title = game.name;
                 string desc = game.summary;
-                string imgPath = covers.Where(cover => cover.game == extID).FirstOrDefault()?.url ?? string.Empty;
+                string imgPath = covers?.Where(cover => cover.game == extID).FirstOrDefault()?.url ?? string.Empty;
                 List<ExternalPlatform> externalPlatforms = game.platforms.Select(plat =>
                 {
-                    Platform p = platforms.Where(platform => platform.id == plat).FirstOrDefault() ?? new Platform();
+                    Platform p = platforms?.Where(platform => platform.id == plat).FirstOrDefault() ?? new Platform();
                     return new ExternalPlatform
                     {
                         ID = p.id,

--- a/gamebox/Connectors/IGDB/IGDBGameSource.cs
+++ b/gamebox/Connectors/IGDB/IGDBGameSource.cs
@@ -36,7 +36,7 @@ namespace GameBox.Connectors.IGDB
                 }
             );
             if (games?.Count == 0)
-                return null;
+                return new List<ExternalGame>();
 
             string gameIDs = string.Join(",", games?.Select(game => game.id) ?? new List<int>());
             List<Cover>? covers = await PostRequest<List<Cover>>(
@@ -49,7 +49,7 @@ namespace GameBox.Connectors.IGDB
                 }
             );
             if (covers?.Count == 0)
-                return null;
+                return new List<ExternalGame>();
 
             string totalIDs = string.Join(",", games.Select(game => string.Join(",", game.platforms.Select(platform => platform.ToString()))));
             int count = totalIDs.Split(",").Length;
@@ -64,7 +64,7 @@ namespace GameBox.Connectors.IGDB
                 }
             );
             if (platforms?.Count == 0)
-                return null;
+                return new List<ExternalGame>();
 
             List<ExternalGame> externalGames = new List<ExternalGame>();
             foreach(Game? game in games)

--- a/gamebox/Connectors/IGDB/IGDBGameSource.cs
+++ b/gamebox/Connectors/IGDB/IGDBGameSource.cs
@@ -158,22 +158,7 @@ namespace GameBox.Connectors.IGDB
                         Name = p.abbreviation
                     };
                 }).ToList();
-                //foreach (int platID in game.platforms)
-                //{
-                //    foreach(Platform p in platformResp)
-                //    {
-                //        if(p.id == platID)
-                //        {
-                //            ExternalPlatform ep = new ExternalPlatform()
-                //            {
-                //                ID = p.id,
-                //                Name = p.abbreviation
-                //            };
-                //            externalPlatforms.Add(ep);
-                //            break;
-                //        }
-                //    }
-                //}
+
                 ExternalGame externalGame = new ExternalGame()
                 {
                     ExternalID = extID,

--- a/gamebox/Connectors/IGDB/IGDBResponse/Cover.cs
+++ b/gamebox/Connectors/IGDB/IGDBResponse/Cover.cs
@@ -4,6 +4,7 @@
     {
         public int id { get; set; }
         public string url { get; set; }
+        public int game {  get; set; }
 
         public Cover()
         {

--- a/gamebox/Connectors/IGameSource.cs
+++ b/gamebox/Connectors/IGameSource.cs
@@ -8,7 +8,7 @@ namespace GameBox.Connectors
     public interface IGameSource
     {
         /// <summary>
-        /// Searches for a game by exact name
+        /// Searches for and returns a set of games based on a name search
         /// </summary>
         /// <param name="q"></param>
         /// <returns></returns>

--- a/gamebox/Connectors/IGameSource.cs
+++ b/gamebox/Connectors/IGameSource.cs
@@ -12,6 +12,6 @@ namespace GameBox.Connectors
         /// </summary>
         /// <param name="q"></param>
         /// <returns></returns>
-        Task<ExternalGame>? SearchGames(string q);
+        Task<List<ExternalGame>> SearchGames(string q);
     }
 }

--- a/gamebox/Controllers/GameController.cs
+++ b/gamebox/Controllers/GameController.cs
@@ -24,7 +24,7 @@ namespace GameBox.Controllers
         /// <param name="q">The title of the game to search for</param>
         /// <returns></returns>
         [HttpGet(Name = "GetGame")]
-        public Task<ExternalGame>? Get(string q)
+        public Task<List<ExternalGame>> Get(string q)
         {
             return service.SearchGames(q);
         }

--- a/gamebox/Models/ExternalGame.cs
+++ b/gamebox/Models/ExternalGame.cs
@@ -1,4 +1,6 @@
-﻿namespace GameBox.Models
+﻿using System.Reflection.Metadata.Ecma335;
+
+namespace GameBox.Models
 {
     /// <summary>
     /// Holds information for a game
@@ -34,6 +36,8 @@
             Description = string.Empty;
             ImagePath = null;
         }
+
+        public static ExternalGame Empty => new ExternalGame();
     }
 
     public class ExternalPlatform
@@ -41,5 +45,11 @@
 
         public int ID { get; set; }
         public string Name { get; set; }
+
+        public ExternalPlatform()
+        {
+            ID = 0;
+            Name = string.Empty;
+        }
     }
 }

--- a/gamebox/Models/ExternalGame.cs
+++ b/gamebox/Models/ExternalGame.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection.Metadata.Ecma335;
-
-namespace GameBox.Models
+﻿namespace GameBox.Models
 {
     /// <summary>
     /// Holds information for a game


### PR DESCRIPTION
**No longer need to search by exact name.**
![image](https://github.com/user-attachments/assets/a2016f58-9a1f-4e46-9b1a-9b97ec464b79)

**Sample JSON response. By default, limit is 10. Perhaps the limit should be customisable, this is not hard to do if it is needed.**
`[
  {
    "externalID": 1025,
    "platforms": [
      {
        "id": 5,
        "name": "Wii"
      },
      {
        "id": 18,
        "name": "NES"
      },
      {
        "id": 37,
        "name": "3DS"
      },
      {
        "id": 41,
        "name": "WiiU"
      },
      {
        "id": 51,
        "name": "fds"
      }
    ],
    "title": "Zelda II: The Adventure of Link",
    "description": "Zelda II: The Adventure of Link is the second major installment in The Legend of Zelda series and the direct sequel to the first game. Like its predecessor, it features dungeons that must be located in the overworld and searched for an item that will prove useful. However, the game presents many very important gameplay changes compared to the previous one, affecting especially the movements and the combat. Moving around the world map involves encounters with enemies that take place on a side-scrolling playfield rather than the top-down perspective for which the series became known.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co1uje.jpg"
  },
  {
    "externalID": 1022,
    "platforms": [
      {
        "id": 5,
        "name": "Wii"
      },
      {
        "id": 18,
        "name": "NES"
      },
      {
        "id": 37,
        "name": "3DS"
      },
      {
        "id": 41,
        "name": "WiiU"
      },
      {
        "id": 51,
        "name": "fds"
      },
      {
        "id": 99,
        "name": "famicom"
      }
    ],
    "title": "The Legend of Zelda",
    "description": "The Legend of Zelda is the first title in the Zelda series, it has marked the history of video games particularly for it's game mechanics and universe. The player controls Link and must make his way through the forests, graveyards, plains and deserts of the Otherworld to find the secret entrances to the eight dungeons and try to restore the broken Triforce. Among the game's mechanics, it was the first time we saw a continuous world that could be freely explored, power-ups that permanently enhanced the main character's abilities and a battery save feature that allowed players to keep their progress instead of having to start over. The gameplay balanced action sequences with discovery, secrets and exploration.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co1uii.jpg"
  },
  {
    "externalID": 1041,
    "platforms": [
      {
        "id": 22,
        "name": "GBC"
      },
      {
        "id": 37,
        "name": "3DS"
      }
    ],
    "title": "The Legend of Zelda: Oracle of Ages",
    "description": "The Legend of Zelda: Oracle of Ages is one of two Zelda titles released for the Game Boy Color, the other being Oracle of Seasons. The game retain many gameplay elements from Link's Awakening such as the graphics, audio and top-view perspective. It also features eight dungeons and a large overworld to explore like in the previous games. Oracle of Ages is said to be more puzzle-oriented than its counterpart being more action-oriented. After completing one of the two games, both can be linked to form a single linear plot with an alternate ending. Oracle of Ages and Oracle of Seasons were often credited as being two of the top games for the Game Boy Color.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co2tw1.jpg"
  },
  {
    "externalID": 1032,
    "platforms": [
      {
        "id": 22,
        "name": "GBC"
      },
      {
        "id": 37,
        "name": "3DS"
      }
    ],
    "title": "The Legend of Zelda: Oracle of Seasons",
    "description": "The Legend of Zelda: Oracle of Seasons is one of two Zelda titles released for the Game Boy Color, the other being Oracle of Ages. The game retain many gameplay elements from Link's Awakening such as the graphics, audio and top-view perspective. It also features eight dungeons and a large overworld to explore like in the previous games. Oracle of Seasons is said to be more action-oriented than its counterpart being more puzzle-oriented. After completing one of the two games, both can be linked to form a single linear plot with an alternate ending. Oracle of Seasons and Oracle of Ages were often credited as being two of the top games for the Game Boy Color.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co2tw0.jpg"
  },
  {
    "externalID": 150080,
    "platforms": [
      {
        "id": 19,
        "name": "SNES"
      }
    ],
    "title": "BS The Legend of Zelda \"MottZilla Patch\"",
    "description": "BS Legend of Zelda \"MottZilla Patch\" is a ROM hack/mod for BS Zelda no Densetsu Map 2. It makes the game able to be played on a real SNES, making it a single game with both BS Zelda games (Maps 1 and 2), with a time limit of 50 minutes per week (weeks on the Satellaview worked like time-limited episodes).",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co3ip4.jpg"
  },
  {
    "externalID": 45142,
    "platforms": [
      {
        "id": 21,
        "name": "NGC"
      },
      {
        "id": 416,
        "name": ""
      }
    ],
    "title": "The Legend of Zelda: Ocarina of Time - Master Quest",
    "description": "The Legend of Zelda: Ocarina of Time - Master Quest is a reworked version of the original Ocarina of Time for the Nintendo 64. Master Quest contains largely the same content as the original game but with more redesigned and difficult dungeons. Master Quest was available on a special bonus disc that also contained the original Ocarina of Time, it was given out in limited quantities with preorders of The Wind Waker. It was previously developed to be released as an expansion to the original game via the Nintendo 64DD, but that version was cancelled due to the lackluster sales of the hardware.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co5zdv.jpg"
  },
  {
    "externalID": 237895,
    "platforms": [
      {
        "id": 130,
        "name": "Switch"
      }
    ],
    "title": "The Legend of Zelda: Breath of the Wild and The Legend of Zelda: Breath of the Wild Expansion Pass Bundle",
    "description": "The Legend of Zelda: Breath of the Wild game packs countless hours of play into a vast world of discovery. That makes it an ideal foundation for more adventures! This special bundle comes with the full game for the Nintendo Switch system and the Expansion Pass, which grants access to three new treasure chests, The Master Trials DLC Pack 1, and The Champions Ballad DLC Pack 2.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co67oa.jpg"
  },
  {
    "externalID": 38319,
    "platforms": [
      {
        "id": 306,
        "name": ""
      }
    ],
    "title": "BS Zelda no Densetsu",
    "description": "BS Zelda no Densetsu was a remake of The Legend of Zelda that was released for the Satellaview attachment of the Super Nintendo Entertainment System in Japan.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co2uzv.jpg"
  },
  {
    "externalID": 152362,
    "platforms": [
      {
        "id": 307,
        "name": "G&W"
      }
    ],
    "title": "Zelda",
    "description": "Zelda is a multiscreen Game & Watch game that was only released in English as a stand-alone system pre-loaded with the single game. It has dual screens which fold in a clamshell design, similar to the Nintendo DS. It was re-released as part of the Nintendo Mini Classics line in 1998 and 2007. The complete game can also be unlocked in Game & Watch Gallery 4 for the Game Boy Advance and Wii U Virtual Console.\n\nIts core formula is based on that of the original The Legend of Zelda, where Link must fight through eight dungeons and obtain the eight shards of the Triforce of Wisdom. However, it bears more gameplay similarities to The Adventure of Link, since it is 2D and from a side-on perspective. The game features an original, though minimal storyline.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co4toa.jpg"
  },
  {
    "externalID": 1029,
    "platforms": [
      {
        "id": 4,
        "name": "N64"
      },
      {
        "id": 5,
        "name": "Wii"
      },
      {
        "id": 41,
        "name": "WiiU"
      },
      {
        "id": 416,
        "name": ""
      }
    ],
    "title": "The Legend of Zelda: Ocarina of Time",
    "description": "The Legend of Zelda: Ocarina of Time is the fifth main installment of The Legend of Zelda series and the first to be released for the Nintendo 64. It was one of the most highly anticipated games of its age, and is listed among the greatest video games ever created by numerous websites and magazines. The gameplay of Ocarina of Time was revolutionary for its time, it has arguably made more of an impact on later games in the series than any of its predecessors even though they had the same cores of exploration, dungeons, puzzles and item usage. Among the gameplay mechanics, one of the most noteworthy is the time-traveling system. The game begins with the player controlling the child Link, but later on an adult Link becomes a playable character as well and each of them has certain unique abilities. Ocarina of Time also introduces the use of music to solve puzzles: as new songs are learned, they can be used to solve puzzles, gain access to new areas and warp to different locations. Dungeon exploration is somewhat more puzzle-oriented than in earlier games but they are not too complex.",
    "imagePath": "//images.igdb.com/igdb/image/upload/t_thumb/co3nnx.jpg"
  }
]`